### PR TITLE
v.0.1.3 Add suite path to error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,16 @@ module.exports = gemini => {
         const suite = obj && obj.__esModule ? obj.default : obj;
 
         if (_.keys(suite).length) {
-            suiteController.createSuite(suite);
+            try {
+                suiteController.createSuite(suite);
+            } catch (e) {
+                e.message = [
+                    "Error creating suite from file: ",
+                    path,
+                    e.message,
+                ].join("\n");
+                throw e;
+            }
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-exports",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Support the exports interface for Gemini",
   "author": "Vladislav Kurkin <b-vladi@yandex-team.ru> (https://github.com/B-Vladi)",
   "license": "UNLICENSED",


### PR DESCRIPTION
Если при парсинге сьюта возникает ошибка, то в стектрейсе не всегда есть информация о том, какой файл парсился в этот момент.
Для облегчения отладки - добавил путь до файла в сообщение ошибке